### PR TITLE
Team Member Editing via Prose.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,3 +51,42 @@ sass:
 
 gems:
   - jekyll-sitemap
+
+
+prose:
+  rooturl: '_team'
+  siteurl: 'http://adhocteam.github.io/'
+  media: 'assets/img/content'
+  ignore:
+    - index.md
+    - _config.yml
+    - /_layouts
+    - /_includes
+  metadata:
+    _team:
+      - name: "title"
+        field:
+          element: "text"
+          label: "Title"
+      - name: "position"
+        field:
+          element: "text"
+          label: "Position"
+          placeholder: "Developer, Designer, etc."
+          value: ""
+          help: "Your position at Ad Hoc"
+      - name: "github_username"
+        field:
+          element: "text"
+          label: "GitHub Username"
+          placeholder: "janedoe"
+          value: ""
+          help: "Your GitHub username, github.com/:username"
+      - name: "photo"
+        field:
+          element: "text"
+          label: "Profile Photo"
+          placeholder: "assets/img/content/doe-jane.jpg"
+          value: ""
+          help: >
+            Once you have uploaded your profile photo, enter the filepath here.


### PR DESCRIPTION
This may not make things any easier, but I thought I would give it a try.

This way, the on boarding process could have a link to: http://prose.io/#adhocteam/adhocteam.github.io/new/test-prose-member-editing/_team, and can get updated right there.

Downsides: 
- yak shaving?
- can’t create branches from Prose. Would need to have 1 long running branch that it works off of.

- - -

@paulsmith @greggersh @goldenmeanie 