### PR TITLE
Wraith example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+group :visual_testing do
+  gem 'wraith'
+end

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,9 @@ exclude:
   - Gemfile.lock
   - CNAME
   - Makefile
+  - javascript
+  - configs
+  - tests
 
 #posts per page
 paginate: 1

--- a/configs/capture.yaml
+++ b/configs/capture.yaml
@@ -1,0 +1,62 @@
+##############################################################
+##############################################################
+# This is an example configuration provided by Wraith.
+# Feel free to amend for your own requirements.
+# ---
+# This particular config is intended to demonstrate how
+# to use Wraith in 'capture' mode, which is best suited to
+# comparing a test and live version of the same website.
+#
+# `wraith capture capture.yaml`
+#
+##############################################################
+##############################################################
+
+# (required) The engine to run Wraith with. Examples: 'phantomjs', 'casperjs', 'slimerjs'
+browser: "phantomjs"
+
+# (required) The domains to take screenshots of.
+domains:
+  current:  "http://adhocteam.us"
+  new:      "http://localhost:4000"
+
+# (required) The paths to capture. All paths should exist for both of the domains specified above.
+paths:
+  home: /
+  case_studies: /case-studies
+  about: /about
+  join: /join
+
+# (required) Screen widths (and optional height) to resize the browser to before taking the screenshot.
+screen_widths:
+  - 320
+  - 600x768
+  - 768
+  - 1024
+  - 1280
+
+# (optional) JavaScript file to execute before taking screenshot of every path. Default: nil
+before_capture: 'javascript/disable_javascript--phantom.js'
+
+# (required) The directory that your screenshots will be stored in
+directory: 'docs/shots'
+
+# (required) Amount of fuzz ImageMagick will use when comparing images. A higher fuzz makes the comparison less strict.
+fuzz: '20%'
+
+# (optional) The maximum acceptable level of difference (in %) between two images before Wraith reports a failure. Default: 0
+threshold: 5
+
+# (optional) Specify the template (and generated thumbnail sizes) for the gallery output.
+gallery:
+  template: 'basic_template' # Examples: 'basic_template' (default), 'slideshow_template'
+  thumb_width:  500
+  thumb_height: 500
+
+# (optional) Choose which results are displayed in the gallery, and in what order. Default: alphanumeric
+# Options:
+#   alphanumeric - all paths (with or without a difference) are shown, sorted by path
+#   diffs_first - all paths (with or without a difference) are shown, sorted by difference size (largest first)
+#   diffs_only - only paths with a difference are shown, sorted by difference size (largest first)
+# Note: different screen widths are always grouped together.
+mode: diffs_first

--- a/configs/history.yaml
+++ b/configs/history.yaml
@@ -1,0 +1,81 @@
+##############################################################
+##############################################################
+# This is an example configuration provided by Wraith.
+# Feel free to amend for your own requirements.
+# ---
+# This particular config is intended to demonstrate how
+# to use Wraith in 'history' mode, which is best suited to
+# making sure your site's appearance remains consistent over
+# time.
+#
+# `wraith history history.yaml` # generate base screenshots
+# `wraith latest history.yaml`  # take new shots and compare
+#
+##############################################################
+##############################################################
+
+# (required) The engine to run Wraith with. Examples: 'phantomjs', 'casperjs', 'slimerjs'
+browser: "casperjs"
+
+# (required) The domain to take screenshots of.
+domains:
+  english: "http://www.bbc.co.uk"
+
+# (required) The paths to capture. This particular config is using casperjs, so we can take screenshots of selectors rather than the entire page.
+paths:
+  clickable_guide:
+    path: /news/entertainment-arts-27221191
+    selector: '.idt__news' # (optional) selector to take a screenshot of
+  clickable_guide__after_click:
+    path: /news/entertainment-arts-27221191
+    selector: '.idt__news'
+    before_capture: 'javascript/beforeCapture--casper_example.js' # (optional) JavaScript file to execute before taking the screenshot of this path.
+
+# (optional) JavaScript file to execute before taking screenshot of every path. Default: nil
+before_capture: 'javascript/wait--casper.js'
+
+# (required) Screen widths (and optional height) to resize the browser to before taking the screenshot.
+screen_widths:
+  - 320
+  - 600x768
+  - 768
+  - 1024
+  - 1280
+
+# (optional) Resize to each screen width (efficient), or reload at each screen width (costly). Default: 'reload'
+resize_or_reload: 'resize'
+
+# (required for history mode, otherwise optional) The directory that your base screenshots will be stored in.
+history_dir: 'shots_base'
+
+# (required) The directory that your latest screenshots will be stored in
+directory: 'shots'
+
+# (required) Amount of fuzz ImageMagick will use when comparing images. A higher fuzz makes the comparison less strict.
+fuzz: '20%'
+
+# (optional) The maximum acceptable level of difference (in %) between two images before Wraith reports a failure. Default: 0
+threshold: 5
+
+# (optional) Specify the template (and generated thumbnail sizes) for the gallery output.
+gallery:
+  template: 'slideshow_template' # Examples: 'basic_template' (default), 'slideshow_template'
+  thumb_width:  200
+  thumb_height: 200
+
+# (optional) Choose which results are displayed in the gallery, and in what order. Default: alphanumeric
+# Options:
+#   alphanumeric - all paths (with or without a difference) are shown, sorted by path
+#   diffs_first - all paths (with or without a difference) are shown, sorted by difference size (largest first)
+#   diffs_only - only paths with a difference are shown, sorted by difference size (largest first)
+# Note: different screen widths are always grouped together.
+mode: diffs_first
+
+# (optional) Choose to run Wraith in verbose mode, for easier debugging. Default: false
+verbose: true
+
+# (optional) Color to highlight the image diff. Default: 'blue'
+highlight_color: red
+
+# (optional) Parameters to pass to Phantom/Casper command line. Default: '--ignore-ssl-errors=true --ssl-protocol=tlsv1'
+phantomjs_options: ''

--- a/configs/spider.yaml
+++ b/configs/spider.yaml
@@ -1,0 +1,60 @@
+##############################################################
+##############################################################
+# This is an example configuration provided by Wraith.
+# Feel free to amend for your own requirements.
+# ---
+# This particular config is intended to demonstrate how
+# to use Wraith in 'spider' mode.
+##############################################################
+##############################################################
+
+
+# Add as many domains as necessary. Key will act as a label
+domains:
+  my_site:       "http://www.example.com"
+  my_other_site: "http://www.test.example.com"
+
+# Notice the absence of a `paths` property. When no paths are provided, Wraith defaults to
+# spidering mode to check your entire website.
+
+# A list of URLs to skip when spidering.
+# Ruby regular expressions can be used, if prefixed with `!ruby/regexp` as defined in the YAML Cookbook​.
+# See http://www.yaml.org/YAML_for_ruby.html#regexps
+spider_skips:
+  - /foo/bar.html           # Matches /foo/bar.html explicitly
+  - !ruby/regexp /^\/baz\// # Matches any URLs that start with /baz
+
+# the filename of the spider file to use. Default: spider.txt
+spider_file: example_com_spider.txt
+
+# the number of days to keep the site spider file
+spider_days: 10
+
+# amount of fuzz ImageMagick will use when comparing images. A higher fuzz makes the comparison less strict.
+fuzz: '20%'
+
+# the maximum acceptable level of difference (in %) between two images.
+# Wraith considers it a failure if an image diff goes above this threshold.
+threshold: 5
+
+# screen widths (and optional height) to resize the browser to before taking the screenshot
+screen_widths:
+  - 320
+  - 600x768
+  - 768
+  - 1024
+  - 1280
+
+# the engine to run Wraith with.
+browser: "phantomjs"
+
+# the directory that your latest screenshots will be stored in
+directory: 'shots'
+
+# choose how results are displayed in the gallery (default is `alphanumeric` if omitted)
+# Different screen widths are always grouped together.
+# Options:
+#   alphanumeric - all paths (with or without a difference) are shown, sorted by path
+#   diffs_first - all paths (with or without a difference) are shown, sorted by difference size (largest first)
+#   diffs_only - only paths with a difference are shown, sorted by difference size (largest first)
+mode: diffs_first

--- a/javascript/cookies_and_headers--casper.js
+++ b/javascript/cookies_and_headers--casper.js
@@ -1,0 +1,16 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (casper, ready) {
+    // reload page with headers set
+    casper.open(casper.page.url, {
+        method: 'get',
+        headers: {
+            'SOME-HEADER': 'fish'
+        }
+    });
+    casper.then(function () {
+        setTimeout(ready, 1000);
+    });
+}

--- a/javascript/cookies_and_headers--phantom.js
+++ b/javascript/cookies_and_headers--phantom.js
@@ -1,0 +1,26 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (phantom, ready) {
+
+    page.customHeaders = {
+        'SOME-HEADER': 'fish'
+    };
+
+    phantom.addCookie({
+        'name': 'ckns_policy',
+        'value': '111',
+        'domain': '.bbc.co.uk'
+    });
+
+    phantom.addCookie({
+        'name': 'locserv',
+        'value': '1#l1#i=6691484:n=Oxford+Circus:h=e@w1#i=8:p=London@d1#1=l:2=e:3=e:4=2@n1#r=40',
+        'domain': '.bbc.co.uk'
+    });
+
+    phantom.open(phantom.url, function () {
+        setTimeout(ready, 5000);
+    });
+}

--- a/javascript/disable_javascript--casper.js
+++ b/javascript/disable_javascript--casper.js
@@ -1,0 +1,11 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (casper, ready) {
+    // disable JavaScript
+    casper.options.pageSettings.javascriptEnabled = false;
+
+    // reload the page without JS enabled
+    casper.thenOpen(casper.page.url);
+}

--- a/javascript/disable_javascript--phantom.js
+++ b/javascript/disable_javascript--phantom.js
@@ -1,0 +1,13 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (phantom, ready) {
+    // disable JavaScript
+    phantom.settings.javascriptEnabled = false;
+
+    // reload the page without JS enabled
+    phantom.open(phantom.url, function () {
+        setTimeout(ready, 5000);
+    });
+}

--- a/javascript/interact--casper.js
+++ b/javascript/interact--casper.js
@@ -1,0 +1,11 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (casper, ready) {
+    // test interaction on the page
+    casper.wait(2000, function() {
+        casper.click('.ns-panel__hotspot--2');
+        ready();
+    });
+}

--- a/javascript/interact--phantom.js
+++ b/javascript/interact--phantom.js
@@ -1,0 +1,17 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (phantom, ready) {
+
+    // test interaction on the page
+    phantom.evaluate(function(){
+        var a = document.querySelector('.ns-panel__hotspot--2');
+        var e = document.createEvent('MouseEvents');
+        e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+        a.dispatchEvent(e);
+        waitforload = true;
+    });
+
+    ready();
+}

--- a/javascript/wait--casper.js
+++ b/javascript/wait--casper.js
@@ -1,0 +1,8 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (casper, ready) {
+    // make Wraith wait a bit longer before taking the screenshot
+    casper.wait(2000, ready); // you MUST call the ready() callback for Wraith to continue
+}

--- a/javascript/wait--phantom.js
+++ b/javascript/wait--phantom.js
@@ -1,0 +1,8 @@
+// ######################################################
+// This is an example module provided by Wraith.
+// Feel free to amend for your own requirements.
+// ######################################################
+module.exports = function (phantom, ready) {
+    // make Wraith wait a bit longer before taking the screenshot
+    setTimeout(ready, 2000); // you MUST call the ready() callback for Wraith to continue
+}


### PR DESCRIPTION
Example using [Wraith](http://bbc-news.github.io/wraith/index.html) as a visual regression testing tool.

To see it in action:

1. [Install dependencies](http://bbc-news.github.io/wraith/os-install.html). 
1. run `bundle install`- installs jekyll and wraith dependencies.
1. run `jekyll s` - starts jekyll, which wraith uses for local screenshots
1. Make some css or markup changes
1. run `bundle exec wraith capture configs/capture.yml` - starts wraith capturing these pages:
  - home
  - case studies
  - about
  - join
1. Visit `localhost:4000/docs/shots/gallery.html`to review shots

- - -

@dannychapman