### PR TITLE
Fix reference to Juliana's profile image

### DIFF
--- a/_team/neelbauer-juliana.md
+++ b/_team/neelbauer-juliana.md
@@ -7,7 +7,7 @@ position: COO
 github_username: neelbauer1
 # add the filename of the image you uploaded to the end of the
 # string below
-photo: /assets/img/content/neelbauer-juliana.png
+photo: /assets/img/content/neelbauer-juliana.jpg
 # Relevant website URLS
 # Do not include your GitHub profile, we add that automatically.
 links:


### PR DESCRIPTION
Fixes format for reference introduced in #82 

<img width="1124" alt="about_ad_hoc_-_ad_hoc" src="https://cloud.githubusercontent.com/assets/215266/17216612/a2561d96-549e-11e6-8673-444ff452e976.png">
